### PR TITLE
Remove `version_tag` in recipe

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,14 @@ environment:
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,13 +3,12 @@
 {% set version_minor   = "24" %}
 {% set version_revison = "5" %}
 {% set version = ".".join([version_major, version_minor, version_revison]) %}
-{% set version_tag = "0.24.5" %}
 {% set sha256 = "f6135ee64b174f449c8857272352c11ca182af05a340237834cedcc9eb390cba" %}
-{% set filename = "v" + version_tag + ".tar.gz" %}
+{% set filename = "v" + version + ".tar.gz" %}
 
 package:
   name: {{ name|lower }}
-  version: {{ version_tag }}
+  version: {{ version }}
 
 source:
   fn: {{ filename }}


### PR DESCRIPTION
`version_tag` was used, because the published latest release was not consistent with the latest tag on GitHub. It seems like this is not a problem anymore.

Will merge after #5 is merged.