### PR TITLE
[TEST] conda smithy update-cb3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,10 +9,10 @@ environment:
     secure: ipv/06DzgA7pzz2CIAtbPxZSsphDtF+JFyoWRnXkn3O8j7oRe3rzqj3LOoq2DZp4
 
   matrix:
-    - CONFIG: win_c_compilervs2008cxx_compilervs2008
+    - CONFIG: win_c_compilervs2008
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
-    - CONFIG: win_c_compilervs2015cxx_compilervs2015
+    - CONFIG: win_c_compilervs2015
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -2,8 +2,6 @@ c_compiler:
 - toolchain_c
 curl:
 - '7.59'
-cxx_compiler:
-- toolchain_cxx
 libiconv:
 - '1.15'
 libssh2:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -4,8 +4,6 @@ c_compiler:
 - toolchain_c
 curl:
 - '7.59'
-cxx_compiler:
-- toolchain_cxx
 libiconv:
 - '1.15'
 libssh2:

--- a/.ci_support/win_c_compilervs2008.yaml
+++ b/.ci_support/win_c_compilervs2008.yaml
@@ -1,9 +1,7 @@
 c_compiler:
-- vs2015
+- vs2008
 curl:
 - '7.59'
-cxx_compiler:
-- vs2015
 libiconv:
 - '1.15'
 libssh2:
@@ -21,8 +19,5 @@ pin_run_as_build:
     max_pin: x.x.x
   zlib:
     max_pin: x.x
-zip_keys:
-- - c_compiler
-  - cxx_compiler
 zlib:
 - '1.2'

--- a/.ci_support/win_c_compilervs2015.yaml
+++ b/.ci_support/win_c_compilervs2015.yaml
@@ -1,9 +1,7 @@
 c_compiler:
-- vs2008
+- vs2015
 curl:
 - '7.59'
-cxx_compiler:
-- vs2008
 libiconv:
 - '1.15'
 libssh2:
@@ -21,8 +19,5 @@ pin_run_as_build:
     max_pin: x.x.x
   zlib:
     max_pin: x.x
-zip_keys:
-- - c_compiler
-  - cxx_compiler
 zlib:
 - '1.2'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,26 +16,27 @@ source:
 
 build:
   number: 0
+  features:
+      - vc9    # [win and py27]
+      - vc10   # [win and py34]
+      - vc14   # [win and py35]
 
 requirements:
   build:
     - cmake
-    - pkg-config      # [not win]
-    - {{ compiler('c') }}
-  host:
+    - python          # [win]
     - msinttypes      # [win]
-    - {{ compiler('c') }}
-  host:
-    - openssl         # [not win]
-    - libiconv        # [osx]
-    - curl
-    - libssh2
+    - openssl 1.0.*   # [not win]
+    - libiconv 1.15   # [osx]
+    - curl >=7.44.0,<8
+    - libssh2 1.8.*
+    - pkg-config      # [not win]
     - zlib
   run:
-    - openssl         # [not win]
-    - libiconv        # [osx]
-    - curl
-    - libssh2
+    - openssl 1.0.*   # [not win]
+    - libiconv 1.15   # [osx]
+    - curl >=7.44.0,<8
+    - libssh2 1.8.*
     - zlib
 
 test:
@@ -149,7 +150,7 @@ test:
     {% set libs = linux_libs %}                             # [linux]
     {% set libs = osx_libs %}                               # [osx]
     {% set libs = win_libs %}                               # [win]
-
+    
     {% for lib in libs %}
     - test -f $PREFIX/lib/{{ lib }}                         # [not win]
     - if not exist {{ lib }} exit 1                         # [win]
@@ -163,9 +164,9 @@ about:
 
   # The remaining entries in this section are optional, but recommended
   description: |
-    libgit2 is a portable, pure C implementation of the Git core methods
-    provided as a re-entrant linkable library with a solid API, allowing
-    you to write native speed custom Git applications in any language
+    libgit2 is a portable, pure C implementation of the Git core methods 
+    provided as a re-entrant linkable library with a solid API, allowing 
+    you to write native speed custom Git applications in any language 
     which supports C bindings.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,6 @@ requirements:
     - zlib
 
 test:
-  requires:
-    - python {{ environ['PY_VER'] + '*' }}  # [win]
   commands:
     # Include files.
     {% set includes = [

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,27 +16,24 @@ source:
 
 build:
   number: 0
-  features:
-      - vc9    # [win and py27]
-      - vc10   # [win and py34]
-      - vc14   # [win and py35]
 
 requirements:
   build:
     - cmake
-    - python          # [win]
-    - msinttypes      # [win]
-    - openssl 1.0.*   # [not win]
-    - libiconv 1.15   # [osx]
-    - curl >=7.44.0,<8
-    - libssh2 1.8.*
     - pkg-config      # [not win]
+    - {{ compiler('c') }}
+  host:
+    - msinttypes      # [win]
+    - openssl         # [not win]
+    - libiconv        # [osx]
+    - curl
+    - libssh2
     - zlib
   run:
-    - openssl 1.0.*   # [not win]
-    - libiconv 1.15   # [osx]
-    - curl >=7.44.0,<8
-    - libssh2 1.8.*
+    - openssl         # [not win]
+    - libiconv        # [osx]
+    - curl
+    - libssh2
     - zlib
 
 test:
@@ -150,7 +147,7 @@ test:
     {% set libs = linux_libs %}                             # [linux]
     {% set libs = osx_libs %}                               # [osx]
     {% set libs = win_libs %}                               # [win]
-    
+
     {% for lib in libs %}
     - test -f $PREFIX/lib/{{ lib }}                         # [not win]
     - if not exist {{ lib }} exit 1                         # [win]
@@ -164,9 +161,9 @@ about:
 
   # The remaining entries in this section are optional, but recommended
   description: |
-    libgit2 is a portable, pure C implementation of the Git core methods 
-    provided as a re-entrant linkable library with a solid API, allowing 
-    you to write native speed custom Git applications in any language 
+    libgit2 is a portable, pure C implementation of the Git core methods
+    provided as a re-entrant linkable library with a solid API, allowing
+    you to write native speed custom Git applications in any language
     which supports C bindings.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,10 @@ build:
 requirements:
   build:
     - cmake
-    - msinttypes      # [win]
     - pkg-config      # [not win]
+    - {{ compiler('c') }}
+  host:
+    - msinttypes      # [win]
     - {{ compiler('c') }}
   host:
     - openssl         # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,28 +16,32 @@ source:
 
 build:
   number: 0
+  features:
+      - vc9    # [win and py27]
+      - vc10   # [win and py34]
+      - vc14   # [win and py35]
 
 requirements:
   build:
     - cmake
-    - pkg-config      # [not win]
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-  host:
+    - python          # [win]
     - msinttypes      # [win]
-    - openssl         # [not win]
-    - libiconv        # [osx]
-    - curl
-    - libssh2
+    - openssl 1.0.*   # [not win]
+    - libiconv 1.15   # [osx]
+    - curl >=7.44.0,<8
+    - libssh2 1.8.*
+    - pkg-config      # [not win]
     - zlib
   run:
-    - openssl         # [not win]
-    - libiconv        # [osx]
-    - curl
-    - libssh2
+    - openssl 1.0.*   # [not win]
+    - libiconv 1.15   # [osx]
+    - curl >=7.44.0,<8
+    - libssh2 1.8.*
     - zlib
 
 test:
+  requires:
+    - python {{ environ['PY_VER'] + '*' }}  # [win]
   commands:
     # Include files.
     {% set includes = [

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,27 +16,24 @@ source:
 
 build:
   number: 0
-  features:
-      - vc9    # [win and py27]
-      - vc10   # [win and py34]
-      - vc14   # [win and py35]
 
 requirements:
   build:
     - cmake
-    - python          # [win]
     - msinttypes      # [win]
-    - openssl 1.0.*   # [not win]
-    - libiconv 1.15   # [osx]
-    - curl >=7.44.0,<8
-    - libssh2 1.8.*
     - pkg-config      # [not win]
+    - {{ compiler('c') }}
+  host:
+    - openssl         # [not win]
+    - libiconv        # [osx]
+    - curl
+    - libssh2
     - zlib
   run:
-    - openssl 1.0.*   # [not win]
-    - libiconv 1.15   # [osx]
-    - curl >=7.44.0,<8
-    - libssh2 1.8.*
+    - openssl         # [not win]
+    - libiconv        # [osx]
+    - curl
+    - libssh2
     - zlib
 
 test:
@@ -150,7 +147,7 @@ test:
     {% set libs = linux_libs %}                             # [linux]
     {% set libs = osx_libs %}                               # [osx]
     {% set libs = win_libs %}                               # [win]
-    
+
     {% for lib in libs %}
     - test -f $PREFIX/lib/{{ lib }}                         # [not win]
     - if not exist {{ lib }} exit 1                         # [win]
@@ -164,9 +161,9 @@ about:
 
   # The remaining entries in this section are optional, but recommended
   description: |
-    libgit2 is a portable, pure C implementation of the Git core methods 
-    provided as a re-entrant linkable library with a solid API, allowing 
-    you to write native speed custom Git applications in any language 
+    libgit2 is a portable, pure C implementation of the Git core methods
+    provided as a re-entrant linkable library with a solid API, allowing
+    you to write native speed custom Git applications in any language
     which supports C bindings.
 
 extra:


### PR DESCRIPTION
Testing `conda smithy update-cb3`.

```
$ conda smithy update-cb3

List of changes done to the recipe:
Renamed build with host
Moving cmake from host to build
Moving `python # [win]` which was used for vc matrix
Moving msinttypes from host to build
Removing pinnings for openssl to use values from conda_build_config.yaml
Removing pinnings for libiconv to use values from conda_build_config.yaml
Removing pinnings for curl to use values from conda_build_config.yaml
Removing pinnings for libssh2 to use values from conda_build_config.yaml
Moving pkg-config from host to build
Removing vc features
Removing features section as it is empty
Adding C compiler
```